### PR TITLE
fix: avoid double slash redirect

### DIFF
--- a/src/components/VerifiedImage.tsx
+++ b/src/components/VerifiedImage.tsx
@@ -108,7 +108,7 @@ export default function VerifiedImage() {
 }
 
 export async function fetchCar(cid: string, gateway: URL) {
-  const url = `${gateway}/ipfs/${cid}`
+  const url = `${gateway}ipfs/${cid}`
   const res = await fetch(url, {
     method: 'GET',
     headers: {
@@ -126,7 +126,7 @@ export async function fetchCar(cid: string, gateway: URL) {
 }
 
 export async function ipfsFetch(ipfsPath: string): Promise<UnixFSEntry[]> {
-  const gatewayUrl = new URL(`https://ipfs.io`)
+  const gatewayUrl = new URL(`https://ipfs.io/`)
   let cid: string = ipfsPath
   if (ipfsPath.startsWith('/ipfs/')) {
     cid = ipfsPath.substring('/ipfs/'.length)


### PR DESCRIPTION
``new URL('https://ipfs.io').toString()`` will always include a trailing slash to indicate an empty `URL.pathname`. 

App requested `https://ipfs.io//ipfs/cid` and gateways normalizes paths, so it always produced overhead when gateway returned HTTP 301 redirect to `https://ipfs.io/ipfs/cid` before returning final payload.

This PR should make things less confusing and remove redirect, which saves 1 request and >100ms. 

cc @2color 